### PR TITLE
CC-26461 Backporting password reset improvements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "spryker/kernel": "^3.30.0",
         "spryker/messenger": "^3.0.0",
         "spryker/security": "^1.3.0",
+        "spryker/security-blocker": "^1.0.0",
         "spryker/security-extension": "^1.0.0",
         "spryker/security-gui-extension": "^1.2.0",
         "spryker/symfony": "^3.5.0",

--- a/data/translation/Zed/de_DE.csv
+++ b/data/translation/Zed/de_DE.csv
@@ -10,3 +10,4 @@ Password,Passwort
 "The password fields must match.","Die Passwortfelder müssen übereinstimmen."
 "Repeat Password","Passwort wiederholen"
 "Recover password","Passwort wiederherstellen"
+"If there is an account associated with this email, you will receive an Email with further instructions.","Falls ein Konto für diese E-Mail-Adresse existiert, werden Sie eine E-Mail mit weiteren Instruktionen erhalten."

--- a/data/translation/Zed/en_US.csv
+++ b/data/translation/Zed/en_US.csv
@@ -10,3 +10,4 @@ Password,Password
 "The password fields must match.","The password fields must match."
 "Repeat Password","Repeat Password"
 "Recover password","Recover password"
+"If there is an account associated with this email, you will receive an Email with further instructions.","If there is an account associated with this email, you will receive an Email with further instructions."

--- a/src/Spryker/Shared/SecurityGui/Transfer/security_gui.transfer.xml
+++ b/src/Spryker/Shared/SecurityGui/Transfer/security_gui.transfer.xml
@@ -35,4 +35,17 @@
         <property name="userConditions" type="UserConditions" strict="true"/>
     </transfer>
 
+    <transfer name="SecurityCheckAuthContext">
+        <property name="type" type="string"/>
+        <property name="ip" type="string"/>
+        <property name="account" type="string"/>
+    </transfer>
+
+    <transfer name="SecurityCheckAuthResponse">
+        <property name="isBlocked" type="bool"/>
+        <property name="numberOfAttempts" type="int"/>
+        <property name="blockedFor" type="int"/>
+        <property name="securityCheckAuthContext" type="SecurityCheckAuthContext"/>
+    </transfer>
+
 </transfers>

--- a/src/Spryker/Zed/SecurityGui/Communication/SecurityGuiCommunicationFactory.php
+++ b/src/Spryker/Zed/SecurityGui/Communication/SecurityGuiCommunicationFactory.php
@@ -17,6 +17,7 @@ use Spryker\Zed\SecurityGui\Communication\Plugin\Security\Handler\UserAuthentica
 use Spryker\Zed\SecurityGui\Communication\Plugin\Security\Provider\UserProvider;
 use Spryker\Zed\SecurityGui\Communication\Security\User;
 use Spryker\Zed\SecurityGui\Communication\Security\UserInterface;
+use Spryker\Zed\SecurityGui\Dependency\Client\SecurityGuiToSecurityBlockerClientInterface;
 use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToMessengerFacadeInterface;
 use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToSecurityFacadeInterface;
 use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToUserFacadeInterface;
@@ -147,5 +148,13 @@ class SecurityGuiCommunicationFactory extends AbstractCommunicationFactory
     public function getUserLoginRestrictionPlugins(): array
     {
         return $this->getProvidedDependency(SecurityGuiDependencyProvider::PLUGINS_USER_LOGIN_RESTRICTION);
+    }
+
+    /**
+     * @return \Spryker\Zed\SecurityGui\Dependency\Client\SecurityGuiToSecurityBlockerClientInterface
+     */
+    public function getSecurityBlockerClient(): SecurityGuiToSecurityBlockerClientInterface
+    {
+        return $this->getProvidedDependency(SecurityGuiDependencyProvider::CLIENT_SECURITY_BLOCKER);
     }
 }

--- a/src/Spryker/Zed/SecurityGui/Dependency/Client/SecurityGuiToSecurityBlockerClientBridge.php
+++ b/src/Spryker/Zed/SecurityGui/Dependency/Client/SecurityGuiToSecurityBlockerClientBridge.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\SecurityGui\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+class SecurityGuiToSecurityBlockerClientBridge implements SecurityGuiToSecurityBlockerClientInterface
+{
+    /**
+     * @var \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface
+     */
+    protected $securityBlockerClient;
+
+    /**
+     * @param \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface $securityBlockerClient
+     */
+    public function __construct($securityBlockerClient)
+    {
+        $this->securityBlockerClient = $securityBlockerClient;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->incrementLoginAttemptCount($securityCheckAuthContextTransfer);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->isAccountBlocked($securityCheckAuthContextTransfer);
+    }
+}

--- a/src/Spryker/Zed/SecurityGui/Dependency/Client/SecurityGuiToSecurityBlockerClientInterface.php
+++ b/src/Spryker/Zed/SecurityGui/Dependency/Client/SecurityGuiToSecurityBlockerClientInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\SecurityGui\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+interface SecurityGuiToSecurityBlockerClientInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+}

--- a/src/Spryker/Zed/SecurityGui/SecurityGuiConfig.php
+++ b/src/Spryker/Zed/SecurityGui/SecurityGuiConfig.php
@@ -56,6 +56,45 @@ class SecurityGuiConfig extends AbstractBundleConfig
     protected const MAX_LENGTH_USER_PASSWORD = 72;
 
     /**
+     * @uses \Spryker\Client\SecurityBlockerBackoffice\SecurityBlockerBackofficeConfig::BACKOFFICE_USER_SECURITY_BLOCKER_ENTITY_TYPE
+     *
+     * @var string
+     */
+    protected const BACKOFFICE_USER_SECURITY_BLOCKER_ENTITY_TYPE = 'back-office-user';
+
+    /**
+     * @var bool
+     */
+    protected const IS_BACKOFFICE_USER_SECURITY_BLOCKER_ENABLED = false;
+
+    /**
+     * Specification:
+     * - Checks if the security blocker is enabled.
+     * - It is disabled by default.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isBackofficeUserSecurityBlockerEnabled(): bool
+    {
+        return static::IS_BACKOFFICE_USER_SECURITY_BLOCKER_ENABLED;
+    }
+
+    /**
+     * Specification:
+     * - Returns the entity identifier that is used to block the password resets.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getBackofficeUserSecurityBlockerEntityType(): string
+    {
+        return static::BACKOFFICE_USER_SECURITY_BLOCKER_ENTITY_TYPE;
+    }
+
+    /**
      * @api
      *
      * @return string

--- a/src/Spryker/Zed/SecurityGui/SecurityGuiDependencyProvider.php
+++ b/src/Spryker/Zed/SecurityGui/SecurityGuiDependencyProvider.php
@@ -9,6 +9,7 @@ namespace Spryker\Zed\SecurityGui;
 
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
+use Spryker\Zed\SecurityGui\Dependency\Client\SecurityGuiToSecurityBlockerClientBridge;
 use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToMessengerFacadeBridge;
 use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToSecurityFacadeBridge;
 use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToUserFacadeBridge;
@@ -19,6 +20,11 @@ use Spryker\Zed\SecurityGui\Dependency\Facade\SecurityGuiToUserPasswordResetFaca
  */
 class SecurityGuiDependencyProvider extends AbstractBundleDependencyProvider
 {
+    /**
+     * @var string
+     */
+    public const CLIENT_SECURITY_BLOCKER = 'CLIENT_SECURITY_BLOCKER';
+
     /**
      * @var string
      */
@@ -70,6 +76,7 @@ class SecurityGuiDependencyProvider extends AbstractBundleDependencyProvider
         $container = $this->addAuthenticationLinkPlugins($container);
         $container = $this->addUserRoleFilterPlugins($container);
         $container = $this->addUserLoginRestrictionPlugins($container);
+        $container = $this->addSecurityBlockerClient($container);
 
         return $container;
     }
@@ -84,6 +91,22 @@ class SecurityGuiDependencyProvider extends AbstractBundleDependencyProvider
         $container = parent::provideBusinessLayerDependencies($container);
 
         $container = $this->addUserFacade($container);
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addSecurityBlockerClient(Container $container)
+    {
+        $container->set(static::CLIENT_SECURITY_BLOCKER, function (Container $container) {
+            return new SecurityGuiToSecurityBlockerClientBridge(
+                $container->getLocator()->securityBlocker()->client(),
+            );
+        });
 
         return $container;
     }


### PR DESCRIPTION
Branch: backport/1.3.1
Ticket: https://spryker.atlassian.net/browse/CC-26461
Version: 1.3.1
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SecurityGui | patch                 |                       |

-----------------------------------------

#### Module SecurityGui

##### Change log

Improvements

- Adjusted `PasswordController::resetRequestAction()` with the behavior that password reset requests are silently blocked when requested too frequently within a short time. 
- Introduced `SecurityGui::isBackofficeUserSecurityBlockerEnabled()` to enable or disable the blocking. It is enabled by default.
- Introduced `SecurityGui::getBackofficeUserSecurityBlockerEntityType()` that returns the string used to identify the blocking type.
- Introduced `SecurityCheckAuthContext` transfer.
- Introduced `SecurityCheckAuthResponse` transfer.
- Added `SecurityBlockerClientInterface` to dependencies.
- Added `SecurityBlocker` module dependency.

